### PR TITLE
Fix misspelling in low pass filter log

### DIFF
--- a/aud/aud.py
+++ b/aud/aud.py
@@ -555,7 +555,7 @@ class Dir(object):
         return True
 
     def afx_lpf(self, cutoff=None):
-        verbose_log("Appling Low Pass Filter")
+        verbose_log("Applying Low Pass Filter")
         if cutoff:
             for file in self.filtered_files:
                 name, ext = split_filename(file)


### PR DESCRIPTION
## Summary
- fix `Appling` typo in low pass filter log message

## Testing
- `pytest -q` *(fails: ConvertError)*

------
https://chatgpt.com/codex/tasks/task_e_687b9eba5bd483228138ccfd39acf6b1