### PR TITLE
Fix watermark overlay

### DIFF
--- a/aud/aud.py
+++ b/aud/aud.py
@@ -455,7 +455,9 @@ class Dir(object):
                         rng = randrange(min, max) + len(watermark)
                         cur += rng
                         if (cur + max + len(watermark)) < len(audio):
-                            audio.overlay(watermark, rng, gain_during_overlay=-2)
+                            audio = audio.overlay(
+                                watermark, rng, gain_during_overlay=-2
+                            )
                         else:
                             break
                     audio.export(join(self.directory_path, file), format=ext)


### PR DESCRIPTION
## Summary
- ensure `afx_watermark` reassigns the overlayed audio

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687b9dcc66908322a436b2d418891634