### PR TITLE
Use pytest.main instead of os.system

### DIFF
--- a/aud/__main__.py
+++ b/aud/__main__.py
@@ -1,7 +1,7 @@
 import sys
-import os
+import pytest
 
 if "--test" in sys.argv:
-    os.system("pytest -xv")
+    sys.exit(pytest.main(["-x", "-v"]))
 elif len(sys.argv) > 1:
     print("--test is the only valid option")


### PR DESCRIPTION
## Summary
- replace `os.system` with a call to `pytest.main`

## Testing
- `pytest -q` *(fails: FileNotFoundError: [Errno 2] No such file or directory: 'ffmpeg')*

------
https://chatgpt.com/codex/tasks/task_e_687bbbf0764c83229b2adde51a6e37ac